### PR TITLE
Skip CREATE BUDGET grant on schema

### DIFF
--- a/src/Snowflake/Connection.php
+++ b/src/Snowflake/Connection.php
@@ -114,6 +114,11 @@ class Connection extends AdapterConnection
 
     public function assignGrantToRole(array $grant): void
     {
+        if ($grant['granted_on'] === 'SCHEMA' && $grant['privilege'] === 'CREATE BUDGET') {
+            // CREATE BUDGET is not supported in Snowflake
+            return;
+        }
+
         $this->useRole($grant['granted_by']);
 
         if ($grant['privilege'] === 'USAGE' && $grant['granted_on'] === 'WAREHOUSE') {


### PR DESCRIPTION
https://keboolaglobal.slack.com/archives/C05564BED96/p1684432122163569

grant CREATE BUDGET ON SCHEMA není v tuto chvíli podporovaný od snowflaku

<img width="1079" alt="image" src="https://github.com/keboola/project-migration-tool/assets/12143866/5e9b91fe-76be-4a92-8012-8f343347bc57">

