### PR TITLE
use role when migrate DB

### DIFF
--- a/src/Migrate.php
+++ b/src/Migrate.php
@@ -388,6 +388,7 @@ SQL;
     public function cloneDatabaseWithGrants(string $mainRole, array $grants): void
     {
         foreach ($this->databases as $database) {
+            $this->sourceConnection->useRole($this->mainMigrationRoleSourceAccount);
             $databaseRole = $this->sourceConnection->getOwnershipRoleOnDatabase($database);
             [
                 'grants' => [


### PR DESCRIPTION
```
developer-portal-v2/keboola.project-migration-tool:1.0.11 container '592253647-592253647--0-keboola-project-migration-tool' failed: (2) [2023-07-14T09:44:51.888787+00:00] CRITICAL: Keboola\SnowflakeDbAdapter\Exception\RuntimeException:Error "odbc_prepare(): SQL error: SQL compilation error: Database 'KEBOOLA_2066' does not exist or not authorized., SQL state 02000 in SQLPrepare" while executing query "SHOW GRANTS ON DATABASE "KEBOOLA_2066";" {"errFile":"/code/vendor/keboola/db-adapter-snowflake/src/ExceptionHandler.php","errLine":46,"errCode":0,"errTrace":"#0 /code/vendor/keboola/db-adapter-snowflake/src/Connection.php(235): Keboola\\SnowflakeDbAdapter\\ExceptionHandler->handleException(Object(ErrorException), 'SHOW GRANTS ON ...')\n#1 /code/src/Snowflake/Connection.php(197): Keboola\\SnowflakeDbAdapter\\Connection->fetchAll('SHOW GRANTS ON ...')\n#2 /code/src/Migrate.php(391): ProjectMigrationTool\\Snowflake\\Connection->getOwnershipRoleOnDatabase('KEBOOLA_2066')\n#3 /code/src/Component.php(73): ProjectMigrationTool\\Migrate->cloneDatabaseWithGrants('KEBOOLA_STORAGE', Array)\n#4 /code/src/Component.php(22): ProjectMigrationTool\\Component->runMigrateData(Object(ProjectMigrationTool\\Migrate))\n#5 /code/vendor/keboola/php-component/src/BaseComponent.php(202): ProjectMigrationTool\\Component->run()\n#6 /code/src/run.php(14): Keboola\\Component\\BaseComponent->execute()\n#7 {main}","errPrevious":"ErrorException"} []

```