### PR TITLE
Set user type if not exists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,8 +85,8 @@ SQLLevel=1
 EOF
 
 # Install data-diff
-RUN pip3 install data-diff --break-system-packages
-RUN pip3 install 'data-diff[snowflake]' --break-system-packages
+RUN pip3 install data-diff --break-system-packages --no-deps
+RUN pip3 install 'data-diff[snowflake]' --break-system-packages --no-deps
 
 ## Composer - deps always cached unless changed
 # First copy only composer files

--- a/src/MigrateStructure.php
+++ b/src/MigrateStructure.php
@@ -588,6 +588,10 @@ SQL;
             fn($v) => !empty($v),
         );
 
+        if (!isset($describeUser['type'])) {
+            $describeUser['type'] = 'PERSON';
+        }
+
         if ($describeUser['type'] !== 'SERVICE') {
             $describeUser['password'] = Helper::generateRandomString();
         }


### PR DESCRIPTION
navazuji ještě na https://github.com/keboola/project-migration-tool/pull/53

because - https://app.datadoghq.eu/logs?query=%40exceptionId%3Aexception-f1de9e090babb8ed21b7233a40d08abd&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice%2Ccomponent&event=AwAAAZnm-ezZnrrSVwAAABhBWm5tLWZZS0FBQjNNbERGSW1ZblhRQUUAAAAkZjE5OWU2ZmEtNTZjMi00NzlkLWIyZDktOTA5NDI5NTczYTExAABfzg&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=56416&storage=hot&stream_sort=desc&viz=stream&from_ts=1759908523504&to_ts=1760513323504&live=true

```
Keboola\DockerBundle\Exception\ApplicationException: developer-portal-v2/keboola.project-migration-tool:1.14.0 container '934109456-934109456--0-keboola-project-migration-tool' failed: (2) [2025-10-15T08:26:02.277308+00:00] CRITICAL: ErrorException:Undefined array key "type" {"errFile":"/code/src/MigrateStructure.php","errLine":591,"errCode":0,"errTrace":"#0 /code/src/MigrateStructure.php(591): Keboola\\Component\\BaseComponent::Keboola\\Component\\{closure}(2, 'Undefined array...', '/code/src/Migra...', 591)\n#1 /code/src/MigrateStructure.php(406): ProjectMigrationTool\\MigrateStructure->createUser(Object(ProjectMigrationTool\\ValueObject\\GrantToRole))\n#2 /code/src/Component.php(81): ProjectMigrationTool\\MigrateStructure->migrateUsersRolesAndGrants(Object(ProjectMigrationTool\\ValueObject\\Role), Array)\n#3 /code/src/Component.php(18): ProjectMigrationTool\\Component->runMigrateStructure()\n#4 /code/vendor/keboola/php-component/src/BaseComponent.php(202): ProjectMigrationTool\\Component->run()\n#5 /code/src/run.php(14): Keboola\\Component\\BaseComponent->execute()\n#6 {main}","errPrevious":[hidden]} []
```
