### PR TITLE
fix: convert permission errors to UserException in createDatabasesFromShares

### DIFF
--- a/src/PrepareMigration.php
+++ b/src/PrepareMigration.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ProjectMigrationTool;
 
 use Keboola\Component\UserException;
+use Keboola\SnowflakeDbAdapter\Exception\RuntimeException;
 use ProjectMigrationTool\Snowflake\Helper;
 
 class PrepareMigration
@@ -143,12 +144,29 @@ SQL;
                 Helper::quoteIdentifier($shareDbName)
             ));
 
-            $this->destinationConnection->query(sprintf(
-                'CREATE DATABASE %s FROM SHARE IDENTIFIER(\'%s.%s\');',
-                Helper::quoteIdentifier($shareDbName),
-                $connection->getAccount(),
-                self::MIGRATION_SHARE_PREFIX . $database
-            ));
+            $shareName = self::MIGRATION_SHARE_PREFIX . $database;
+            try {
+                $this->destinationConnection->query(sprintf(
+                    'CREATE DATABASE %s FROM SHARE IDENTIFIER(\'%s.%s\');',
+                    Helper::quoteIdentifier($shareDbName),
+                    $connection->getAccount(),
+                    $shareName
+                ));
+            } catch (RuntimeException $e) {
+                if (str_contains($e->getMessage(), 'Insufficient privileges')
+                    || str_contains($e->getMessage(), 'SQL access control error')
+                ) {
+                    throw new UserException(sprintf(
+                        'Insufficient privileges to create database from share "%s". ' .
+                        'The destination Snowflake user needs the IMPORT SHARE privilege ' .
+                        'or a role with sufficient permissions to create databases from shares. ' .
+                        'Original error: %s',
+                        $shareName,
+                        $e->getMessage()
+                    ));
+                }
+                throw $e;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

When creating a database from a Snowflake share fails due to insufficient privileges, the error was previously thrown as an internal application error (RuntimeException). This PR catches permission-related errors and converts them to a UserException with a helpful message explaining that the destination Snowflake user needs the IMPORT SHARE privilege.

This was triggered by an error in Datadog logs where a migration failed with: `SQL access control error: Insufficient privileges to operate on account 'BL37358'`

## Review & Testing Checklist for Human

- [ ] Verify the error message strings ("Insufficient privileges", "SQL access control error") match what Snowflake actually returns for permission errors - the string matching approach is somewhat fragile
- [ ] Confirm the suggested fix in the error message (IMPORT SHARE privilege) is accurate for this specific operation
- [ ] Consider if similar error handling should be added to other methods in PrepareMigration.php (createReplication, createShare) that also execute privileged Snowflake operations

**Test plan**: To verify end-to-end, you would need to run a migration with a destination Snowflake user that lacks the IMPORT SHARE privilege and confirm the error message is now user-friendly rather than an internal error.

### Notes

Link to Devin run: https://app.devin.ai/sessions/ea279565e77049b298b4cc8d85016d6f
Requested by: @ZdenekSrotyr

## Release Notes
**Justification, description**

Improved error handling for permission errors when creating databases from Snowflake shares during project migration.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Low risk - converts internal errors to user-friendly errors for a specific permission failure case.

**Deployment Plan**

N/A

**Rollback Plan**

N/A

**Post-Release Support Plan**

N/A