### PR TITLE
[AJDA-2604] Use Snowflake replication group for cross-region migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,33 @@ databases, the cleanup also drops those replica databases on the migrate account
 names are freed and they stop consuming storage. Same-region migrations do not use a
 replication group, so creation and teardown are no-ops.
 
-**Deployment prerequisite:** the configured source and migrate roles must hold the
-privilege to create and drop replication groups (`CREATE REPLICATION GROUP` on the source
-account, `CREATE REPLICATION GROUP ... AS REPLICA` on the migrate account, and `OWNERSHIP`
-to drop them). The tool runs these statements under the configured roles, not `ACCOUNTADMIN`.
+**Deployment prerequisites**
+
+The tool runs the replication-group statements under the configured roles (not
+`ACCOUNTADMIN`), so those roles must hold the `CREATE REPLICATION GROUP` privilege. Grant it
+(as `ACCOUNTADMIN`) on **both** accounts — on the source account to the configured source
+role, and on the migrate account to the configured migrate role:
+
+```sql
+-- On the SOURCE account (creates the primary replication group):
+GRANT CREATE REPLICATION GROUP ON ACCOUNT TO ROLE <source_role>;
+
+-- On the MIGRATE account (creates the secondary/replica replication group):
+GRANT CREATE REPLICATION GROUP ON ACCOUNT TO ROLE <migrate_role>;
+```
+
+Without these grants the run fails with `Insufficient privileges to operate on account ...
+must have CREATE REPLICATION GROUP granted on ACCOUNT`.
+
+If any database in `migrateDatabases` already has **standalone** database replication enabled
+(from the previous per-database approach, via `ALTER DATABASE ... ENABLE REPLICATION TO
+ACCOUNTS`), it must be disabled before it can be added to a replication group. Otherwise the
+run fails with `Database replication for '<db>' must be disabled before it can be added to a
+replication group`. Disable it on the **source** account for each affected database:
+
+```sql
+SELECT SYSTEM$DISABLE_DATABASE_REPLICATION('<database_name>');
+```
 
 Tunable parameters (optional):
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ GRANT CREATE REPLICATION GROUP ON ACCOUNT TO ROLE <migrate_role>;
 Without these grants the run fails with `Insufficient privileges to operate on account ...
 must have CREATE REPLICATION GROUP granted on ACCOUNT`.
 
+Replication groups authorize accounts by their **organization account identifier**
+(`<organization_name>.<account_name>`), not by the legacy `<region>.<account_locator>` form.
+The tool reads these via `CURRENT_ORGANIZATION_NAME()` / `CURRENT_ACCOUNT_NAME()`. Both the
+source and migrate accounts must therefore belong to the **same Snowflake organization** and
+be enabled for replication; otherwise the secondary creation fails with `This account is not
+authorized to create a secondary replica of this primary replication group`.
+
 If any database in `migrateDatabases` already has **standalone** database replication enabled
 (from the previous per-database approach, via `ALTER DATABASE ... ENABLE REPLICATION TO
 ACCOUNTS`), it must be disabled before it can be added to a replication group. Otherwise the

--- a/README.md
+++ b/README.md
@@ -33,6 +33,34 @@ CREATE USER "MIGRATE" PASSWORD='MIGRATE_PASSWORD' DEFAULT_ROLE='SOURCE_MAIN_MIGR
 GRANT ROLE "ACCOUNTADMIN" TO USER "MIGRATE";
 ```
 
+### Cross-region replication
+
+For cross-region migrations the tool creates a single Snowflake replication group on the
+source account, replicates it to the migrate account, and refreshes it. The refresh is
+awaited by polling `REPLICATION_GROUP_REFRESH_PROGRESS`; progress is logged on each poll.
+
+The group name is derived deterministically from the set of migrated databases
+(`MIGRATION_RG_<hash>`). The same migration reuses the same group across repeated runs
+(idempotent), while migrations with different database sets get distinct names so parallel
+migrations never collide on a shared group.
+
+The replication group is dropped during the cleanup phase (`runCleanup`). Because dropping a
+secondary replication group leaves its member databases behind as writable standalone
+databases, the cleanup also drops those replica databases on the migrate account so their
+names are freed and they stop consuming storage. Same-region migrations do not use a
+replication group, so creation and teardown are no-ops.
+
+**Deployment prerequisite:** the configured source and migrate roles must hold the
+privilege to create and drop replication groups (`CREATE REPLICATION GROUP` on the source
+account, `CREATE REPLICATION GROUP ... AS REPLICA` on the migrate account, and `OWNERSHIP`
+to drop them). The tool runs these statements under the configured roles, not `ACCOUNTADMIN`.
+
+Tunable parameters (optional):
+
+- `replicationRefreshTimeout` (seconds, default `3600`) — fail the run if the refresh
+  does not complete within this time.
+- `replicationRefreshPollInterval` (seconds, default `30`) — wait between progress polls.
+
 ## On Migrate Snowflake account (only if you migrate to a different region)
     
 ```sql

--- a/src/Cleanup.php
+++ b/src/Cleanup.php
@@ -10,6 +10,7 @@ use Keboola\SnowflakeDbAdapter\QueryBuilder;
 use ProjectMigrationTool\Configuration\Config;
 use ProjectMigrationTool\Snowflake\Connection;
 use ProjectMigrationTool\Snowflake\Helper;
+use ProjectMigrationTool\Snowflake\ReplicationGroup;
 use ProjectMigrationTool\ValueObject\FutureGrantToRole;
 use ProjectMigrationTool\ValueObject\GrantToRole;
 use ProjectMigrationTool\ValueObject\GrantToUser;
@@ -26,7 +27,39 @@ class Cleanup
         readonly Connection $sourceConnection,
         readonly Connection $destinationConnection,
         readonly LoggerInterface $logger,
+        readonly ?Connection $migrateConnection = null,
     ) {
+    }
+
+    public function teardownReplication(): void
+    {
+        if ($this->sourceConnection->getRegion() === $this->destinationConnection->getRegion()) {
+            // Same-region migration never created a replication group; nothing to tear down.
+            return;
+        }
+        if (!$this->migrateConnection) {
+            throw new UserException('Migration connection is not set');
+        }
+
+        $groupName = ReplicationGroup::buildName($this->config->getDatabases());
+
+        // Drop the replica group on the migrate account first, then the primary on source.
+        $this->logger->info(sprintf('Dropping replica replication group "%s" on migrate account.', $groupName));
+        $this->migrateConnection->query(ReplicationGroup::dropSql($groupName));
+
+        // Dropping a secondary replication group leaves its member databases behind as writable
+        // standalone databases. Drop them so their names are freed and they stop consuming storage
+        // on the migrate (landing-zone) account.
+        foreach ($this->config->getDatabases() as $database) {
+            $this->logger->info(sprintf('Dropping replica database "%s" on migrate account.', $database));
+            $this->migrateConnection->query(sprintf(
+                'DROP DATABASE IF EXISTS %s;',
+                Helper::quoteIdentifier($database)
+            ));
+        }
+
+        $this->logger->info(sprintf('Dropping replication group "%s" on source account.', $groupName));
+        $this->sourceConnection->query(ReplicationGroup::dropSql($groupName));
     }
 
     public function sourceAccount(): void

--- a/src/Component.php
+++ b/src/Component.php
@@ -125,6 +125,10 @@ class Component extends BaseComponent
 
         $this->getLogger()->info('Post-migration cleanup.');
         $cleanup->postMigration();
+
+        // Tear down the cross-region replication group (no-op for same-region migrations).
+        $this->getLogger()->info('Tearing down replication group.');
+        $cleanup->teardownReplication();
     }
 
     private function runCheckMigratedData(): void

--- a/src/Configuration/Config.php
+++ b/src/Configuration/Config.php
@@ -26,6 +26,16 @@ class Config extends BaseConfig
         return $this->getStringValue(['parameters', 'warehouseSize'], 'SMALL');
     }
 
+    public function getReplicationRefreshTimeout(): int
+    {
+        return $this->getIntValue(['parameters', 'replicationRefreshTimeout'], 3600);
+    }
+
+    public function getReplicationRefreshPollInterval(): int
+    {
+        return $this->getIntValue(['parameters', 'replicationRefreshPollInterval'], 30);
+    }
+
     public function getRunAction(): string
     {
         return $this->getStringValue(['parameters', 'action'], 'run');

--- a/src/Configuration/ConfigDefinition.php
+++ b/src/Configuration/ConfigDefinition.php
@@ -95,6 +95,8 @@ class ConfigDefinition extends BaseConfigDefinition
                 ->scalarNode('stackUrl')->end()
                 ->scalarNode('#projectsToken')->end()
                 ->enumNode('warehouseSize')->values(['SMALL', 'MEDIUM', 'LARGE'])->defaultValue('SMALL')->end()
+                ->integerNode('replicationRefreshTimeout')->min(1)->defaultValue(3600)->end()
+                ->integerNode('replicationRefreshPollInterval')->min(1)->defaultValue(30)->end()
                 ->booleanNode('skipCheck')->defaultFalse()->end()
                 ->booleanNode('synchronize')->defaultFalse()->end()
                 ->booleanNode('dryPremigrationCleanupRun')->defaultTrue()->end()

--- a/src/MigrateFactory.php
+++ b/src/MigrateFactory.php
@@ -72,6 +72,7 @@ class MigrateFactory
             $this->sourceConnection,
             $this->targetConnection,
             $this->logger,
+            $this->migrateConnection ?? null,
         );
     }
 
@@ -81,9 +82,11 @@ class MigrateFactory
             throw new RuntimeException('Source connection is required for migration preparation');
         }
         return new PrepareMigration(
+            $this->config,
             $this->config->getDatabases(),
             $this->sourceConnection,
             $this->targetConnection,
+            $this->logger,
             $this->migrateConnection ?? null,
         );
     }

--- a/src/PrepareMigration.php
+++ b/src/PrepareMigration.php
@@ -36,7 +36,9 @@ class PrepareMigration
 
         $groupName = ReplicationGroup::buildName($this->databases);
 
-        // 1. Create (or ensure) the replication group on the SOURCE account, allowing the migrate account.
+        // 1. Create (or ensure) the replication group on the SOURCE account, allowing the migrate
+        //    account. The group name is derived from the database set, so an existing group with
+        //    this name already has exactly these allowed databases (no membership reconcile needed).
         $this->logger->info(sprintf('Ensuring replication group "%s" on source account.', $groupName));
         $this->sourceConnection->query(ReplicationGroup::createOnSourceSql(
             $groupName,
@@ -45,15 +47,7 @@ class PrepareMigration
             $this->migrateConnection->getAccountName(),
         ));
 
-        // 2. Reconcile allowed databases idempotently. The group name is derived from the database
-        //    set, so a re-run of the same migration reuses the same group; this keeps its membership
-        //    in sync with the configured databases.
-        $this->sourceConnection->query(ReplicationGroup::setAllowedDatabasesSql(
-            $groupName,
-            $this->databases,
-        ));
-
-        // 3. Create (or ensure) the replica replication group on the MIGRATE account.
+        // 2. Create (or ensure) the replica replication group on the MIGRATE account.
         $this->logger->info(sprintf('Ensuring replica replication group "%s" on migrate account.', $groupName));
         $this->migrateConnection->query(ReplicationGroup::createReplicaSql(
             $groupName,
@@ -61,10 +55,10 @@ class PrepareMigration
             $this->sourceConnection->getAccountName(),
         ));
 
-        // 4. Ensure a warehouse to drive the refresh.
+        // 3. Ensure a warehouse to drive the refresh.
         $this->ensureMigrateWarehouse();
 
-        // 5. Trigger the refresh on the migrate account and poll until complete.
+        // 4. Trigger the refresh on the migrate account and poll until complete.
         $this->logger->info(sprintf('Refreshing replication group "%s".', $groupName));
         $this->migrateConnection->query(ReplicationGroup::refreshSql($groupName));
 

--- a/src/PrepareMigration.php
+++ b/src/PrepareMigration.php
@@ -5,16 +5,21 @@ declare(strict_types=1);
 namespace ProjectMigrationTool;
 
 use Keboola\Component\UserException;
+use ProjectMigrationTool\Configuration\Config;
 use ProjectMigrationTool\Snowflake\Helper;
+use ProjectMigrationTool\Snowflake\ReplicationGroup;
+use Psr\Log\LoggerInterface;
 
 class PrepareMigration
 {
     private const MIGRATION_SHARE_PREFIX = 'MIGRATION_SHARE_';
 
     public function __construct(
+        readonly Config $config,
         readonly array $databases,
         readonly Snowflake\Connection $sourceConnection,
         readonly Snowflake\Connection $destinationConnection,
+        readonly LoggerInterface $logger,
         readonly ?Snowflake\Connection $migrateConnection = null,
     ) {
     }
@@ -22,57 +27,73 @@ class PrepareMigration
     public function createReplication(): void
     {
         if ($this->sourceConnection->getRegion() === $this->destinationConnection->getRegion()) {
+            // Same-region migration uses sharing only; no replication group needed.
             return;
         }
         if (!$this->migrateConnection) {
             throw new UserException('Migration connection is not set');
         }
-        foreach ($this->databases as $database) {
-            // Allow replication on source database
-            $this->sourceConnection->query(sprintf(
-                'ALTER DATABASE %s ENABLE REPLICATION TO ACCOUNTS %s.%s;',
-                Helper::quoteIdentifier($database),
-                $this->migrateConnection->getRegion(),
-                $this->migrateConnection->getAccount()
-            ));
 
-            // Waiting for previous SQL query
-            sleep(5);
+        $groupName = ReplicationGroup::buildName($this->databases);
 
-            // Migration database sqls
-            $this->migrateConnection->query(sprintf(
-                'CREATE DATABASE IF NOT EXISTS %s AS REPLICA OF %s.%s.%s;',
-                Helper::quoteIdentifier($database),
-                $this->sourceConnection->getRegion(),
-                $this->sourceConnection->getAccount(),
-                Helper::quoteIdentifier($database)
-            ));
+        // 1. Create (or ensure) the replication group on the SOURCE account, allowing the migrate account.
+        $this->logger->info(sprintf('Ensuring replication group "%s" on source account.', $groupName));
+        $this->sourceConnection->query(ReplicationGroup::createOnSourceSql(
+            $groupName,
+            $this->databases,
+            $this->migrateConnection->getRegion(),
+            $this->migrateConnection->getAccount(),
+        ));
 
-            $this->migrateConnection->query(sprintf(
-                'USE DATABASE %s',
-                Helper::quoteIdentifier($database)
-            ));
+        // 2. Reconcile membership idempotently (handles re-runs where the database set changed).
+        $this->sourceConnection->query(ReplicationGroup::setAllowedDatabasesSql(
+            $groupName,
+            $this->databases,
+        ));
 
-            $this->migrateConnection->query('USE SCHEMA PUBLIC');
+        // 3. Create (or ensure) the replica replication group on the MIGRATE account.
+        $this->logger->info(sprintf('Ensuring replica replication group "%s" on migrate account.', $groupName));
+        $this->migrateConnection->query(ReplicationGroup::createReplicaSql(
+            $groupName,
+            $this->sourceConnection->getRegion(),
+            $this->sourceConnection->getAccount(),
+        ));
 
-            // Create and use warehouse for replicate data
-            $sql = <<<SQL
+        // 4. Ensure a warehouse to drive the refresh.
+        $this->ensureMigrateWarehouse();
+
+        // 5. Trigger the refresh on the migrate account and poll until complete.
+        $this->logger->info(sprintf('Refreshing replication group "%s".', $groupName));
+        $this->migrateConnection->query(ReplicationGroup::refreshSql($groupName));
+
+        $replicationGroup = new ReplicationGroup();
+        $migrateConnection = $this->migrateConnection;
+        $replicationGroup->waitForRefresh(
+            $groupName,
+            fetchProgress: fn(): array => $migrateConnection->fetchAll(
+                ReplicationGroup::refreshProgressSql($groupName)
+            ),
+            sleeper: fn(int $seconds): int => sleep($seconds),
+            clock: fn(): int => time(),
+            logger: $this->logger,
+            timeoutSeconds: $this->config->getReplicationRefreshTimeout(),
+            pollIntervalSeconds: $this->config->getReplicationRefreshPollInterval(),
+        );
+    }
+
+    private function ensureMigrateWarehouse(): void
+    {
+        assert($this->migrateConnection !== null);
+
+        $this->migrateConnection->query(<<<SQL
 CREATE WAREHOUSE IF NOT EXISTS "migrate"
     WITH WAREHOUSE_SIZE = 'Small'
         WAREHOUSE_TYPE = 'STANDARD'
         AUTO_SUSPEND = 300
         AUTO_RESUME = true
 ;
-SQL;
-            $this->migrateConnection->query($sql);
-            $this->migrateConnection->query('USE WAREHOUSE "migrate";');
-
-            // Run replicate of data
-            $this->migrateConnection->query(sprintf(
-                'ALTER DATABASE %s REFRESH',
-                Helper::quoteIdentifier($database)
-            ));
-        }
+SQL);
+        $this->migrateConnection->query('USE WAREHOUSE "migrate";');
     }
 
     public function createShare(): void

--- a/src/PrepareMigration.php
+++ b/src/PrepareMigration.php
@@ -45,7 +45,9 @@ class PrepareMigration
             $this->migrateConnection->getAccount(),
         ));
 
-        // 2. Reconcile membership idempotently (handles re-runs where the database set changed).
+        // 2. Reconcile allowed databases idempotently. The group name is derived from the database
+        //    set, so a re-run of the same migration reuses the same group; this keeps its membership
+        //    in sync with the configured databases.
         $this->sourceConnection->query(ReplicationGroup::setAllowedDatabasesSql(
             $groupName,
             $this->databases,

--- a/src/PrepareMigration.php
+++ b/src/PrepareMigration.php
@@ -41,8 +41,8 @@ class PrepareMigration
         $this->sourceConnection->query(ReplicationGroup::createOnSourceSql(
             $groupName,
             $this->databases,
-            $this->migrateConnection->getRegion(),
-            $this->migrateConnection->getAccount(),
+            $this->migrateConnection->getOrganizationName(),
+            $this->migrateConnection->getAccountName(),
         ));
 
         // 2. Reconcile allowed databases idempotently. The group name is derived from the database
@@ -57,8 +57,8 @@ class PrepareMigration
         $this->logger->info(sprintf('Ensuring replica replication group "%s" on migrate account.', $groupName));
         $this->migrateConnection->query(ReplicationGroup::createReplicaSql(
             $groupName,
-            $this->sourceConnection->getRegion(),
-            $this->sourceConnection->getAccount(),
+            $this->sourceConnection->getOrganizationName(),
+            $this->sourceConnection->getAccountName(),
         ));
 
         // 4. Ensure a warehouse to drive the refresh.

--- a/src/Snowflake/Connection.php
+++ b/src/Snowflake/Connection.php
@@ -18,6 +18,10 @@ class Connection extends AdapterConnection
 
     private ?string $account = null;
 
+    private ?string $organizationName = null;
+
+    private ?string $accountName = null;
+
     private ?string $actualRole = null;
 
     private string $defaultRole;
@@ -81,6 +85,28 @@ class Connection extends AdapterConnection
         }
 
         return $this->account;
+    }
+
+    public function getOrganizationName(): string
+    {
+        if (!$this->organizationName) {
+            $result = $this->fetchAll('SELECT CURRENT_ORGANIZATION_NAME() AS "organizationName";');
+
+            $this->organizationName = $result[0]['organizationName'];
+        }
+
+        return $this->organizationName;
+    }
+
+    public function getAccountName(): string
+    {
+        if (!$this->accountName) {
+            $result = $this->fetchAll('SELECT CURRENT_ACCOUNT_NAME() AS "accountName";');
+
+            $this->accountName = $result[0]['accountName'];
+        }
+
+        return $this->accountName;
     }
 
     public function getCurrentRole(): string

--- a/src/Snowflake/ReplicationGroup.php
+++ b/src/Snowflake/ReplicationGroup.php
@@ -66,18 +66,6 @@ class ReplicationGroup
     }
 
     /**
-     * @param string[] $databases
-     */
-    public static function setAllowedDatabasesSql(string $groupName, array $databases): string
-    {
-        return sprintf(
-            'ALTER REPLICATION GROUP %s SET ALLOWED_DATABASES = %s;',
-            Helper::quoteIdentifier($groupName),
-            self::quoteDatabaseList($databases),
-        );
-    }
-
-    /**
      * References the primary group by the source account's organization account identifier
      * (`<organization_name>.<account_name>.<group_name>`).
      */

--- a/src/Snowflake/ReplicationGroup.php
+++ b/src/Snowflake/ReplicationGroup.php
@@ -23,6 +23,10 @@ class ReplicationGroup
      * group name. The database list is upper-cased and sorted before hashing so neither the
      * order nor the casing in the configuration affects the result.
      *
+     * The whole name is upper-cased so it matches Snowflake's default identifier casing. This
+     * matters for REPLICATION_GROUP_REFRESH_PROGRESS, which folds its string argument to upper
+     * case: a quoted lower-case group name would be stored case-sensitively and never match.
+     *
      * @param string[] $databases
      */
     public static function buildName(array $databases): string
@@ -33,7 +37,7 @@ class ReplicationGroup
         );
         sort($normalized);
 
-        return self::NAME_PREFIX . substr(hash('sha256', implode(',', $normalized)), 0, 32);
+        return self::NAME_PREFIX . strtoupper(substr(hash('sha256', implode(',', $normalized)), 0, 32));
     }
 
     /**

--- a/src/Snowflake/ReplicationGroup.php
+++ b/src/Snowflake/ReplicationGroup.php
@@ -37,13 +37,17 @@ class ReplicationGroup
     }
 
     /**
+     * Replication groups authorize accounts by their organization account identifier
+     * (`<organization_name>.<account_name>`), not by the legacy `<region>.<account_locator>`
+     * form, so the migrate account is passed as organization name + account name.
+     *
      * @param string[] $databases
      */
     public static function createOnSourceSql(
         string $groupName,
         array $databases,
-        string $migrateRegion,
-        string $migrateAccount,
+        string $migrateOrganizationName,
+        string $migrateAccountName,
     ): string {
         return sprintf(
             'CREATE REPLICATION GROUP IF NOT EXISTS %s '
@@ -52,8 +56,8 @@ class ReplicationGroup
             . 'ALLOWED_ACCOUNTS = %s.%s;',
             Helper::quoteIdentifier($groupName),
             self::quoteDatabaseList($databases),
-            $migrateRegion,
-            $migrateAccount,
+            $migrateOrganizationName,
+            $migrateAccountName,
         );
     }
 
@@ -69,16 +73,20 @@ class ReplicationGroup
         );
     }
 
+    /**
+     * References the primary group by the source account's organization account identifier
+     * (`<organization_name>.<account_name>.<group_name>`).
+     */
     public static function createReplicaSql(
         string $groupName,
-        string $sourceRegion,
-        string $sourceAccount,
+        string $sourceOrganizationName,
+        string $sourceAccountName,
     ): string {
         return sprintf(
             'CREATE REPLICATION GROUP IF NOT EXISTS %s AS REPLICA OF %s.%s.%s;',
             Helper::quoteIdentifier($groupName),
-            $sourceRegion,
-            $sourceAccount,
+            $sourceOrganizationName,
+            $sourceAccountName,
             Helper::quoteIdentifier($groupName),
         );
     }

--- a/src/Snowflake/ReplicationGroup.php
+++ b/src/Snowflake/ReplicationGroup.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProjectMigrationTool\Snowflake;
+
+use Keboola\Component\UserException;
+use Keboola\SnowflakeDbAdapter\QueryBuilder;
+use Psr\Log\LoggerInterface;
+
+class ReplicationGroup
+{
+    private const TERMINAL_FAILURE_PHASES = ['FAILED', 'CANCELED'];
+
+    private const NAME_PREFIX = 'MIGRATION_RG_';
+
+    /**
+     * Builds a deterministic replication group name from the migrated databases.
+     *
+     * The name is stable across repeated runs of the same migration (same database set
+     * => same name, so the group can be reused idempotently) yet differs between migrations
+     * with different database sets, so parallel migrations never collide on a single shared
+     * group name. The database list is upper-cased and sorted before hashing so neither the
+     * order nor the casing in the configuration affects the result.
+     *
+     * @param string[] $databases
+     */
+    public static function buildName(array $databases): string
+    {
+        $normalized = array_map(
+            fn(string $database): string => strtoupper($database),
+            $databases,
+        );
+        sort($normalized);
+
+        return self::NAME_PREFIX . substr(hash('sha256', implode(',', $normalized)), 0, 32);
+    }
+
+    /**
+     * @param string[] $databases
+     */
+    public static function createOnSourceSql(
+        string $groupName,
+        array $databases,
+        string $migrateRegion,
+        string $migrateAccount,
+    ): string {
+        return sprintf(
+            'CREATE REPLICATION GROUP IF NOT EXISTS %s '
+            . 'OBJECT_TYPES = DATABASES '
+            . 'ALLOWED_DATABASES %s '
+            . 'ALLOWED_ACCOUNTS = %s.%s;',
+            Helper::quoteIdentifier($groupName),
+            self::quoteDatabaseList($databases),
+            $migrateRegion,
+            $migrateAccount,
+        );
+    }
+
+    /**
+     * @param string[] $databases
+     */
+    public static function setAllowedDatabasesSql(string $groupName, array $databases): string
+    {
+        return sprintf(
+            'ALTER REPLICATION GROUP %s SET ALLOWED_DATABASES %s;',
+            Helper::quoteIdentifier($groupName),
+            self::quoteDatabaseList($databases),
+        );
+    }
+
+    public static function createReplicaSql(
+        string $groupName,
+        string $sourceRegion,
+        string $sourceAccount,
+    ): string {
+        return sprintf(
+            'CREATE REPLICATION GROUP IF NOT EXISTS %s AS REPLICA OF %s.%s.%s;',
+            Helper::quoteIdentifier($groupName),
+            $sourceRegion,
+            $sourceAccount,
+            Helper::quoteIdentifier($groupName),
+        );
+    }
+
+    public static function refreshSql(string $groupName): string
+    {
+        return sprintf('ALTER REPLICATION GROUP %s REFRESH;', Helper::quoteIdentifier($groupName));
+    }
+
+    public static function refreshProgressSql(string $groupName): string
+    {
+        return sprintf(
+            'SELECT * FROM TABLE(INFORMATION_SCHEMA.REPLICATION_GROUP_REFRESH_PROGRESS(%s));',
+            QueryBuilder::quote($groupName),
+        );
+    }
+
+    public static function dropSql(string $groupName): string
+    {
+        return sprintf('DROP REPLICATION GROUP IF EXISTS %s;', Helper::quoteIdentifier($groupName));
+    }
+
+    /**
+     * Poll REPLICATION_GROUP_REFRESH_PROGRESS until the refresh completes.
+     *
+     * @param callable():array<int,array<string,mixed>> $fetchProgress
+     * @param callable(int):mixed $sleeper
+     * @param callable():int $clock epoch seconds
+     */
+    public function waitForRefresh(
+        string $groupName,
+        callable $fetchProgress,
+        callable $sleeper,
+        callable $clock,
+        LoggerInterface $logger,
+        int $timeoutSeconds,
+        int $pollIntervalSeconds,
+    ): void {
+        $startedAt = $clock();
+        $first = true;
+
+        while (true) {
+            if (!$first) {
+                $sleeper($pollIntervalSeconds);
+            }
+            $first = false;
+
+            $rows = $fetchProgress();
+            $this->logProgress($groupName, $rows, $logger);
+
+            // Terminal failure: stop immediately, do not wait for the timeout.
+            $failedPhase = self::failedPhase($rows);
+            if ($failedPhase !== null) {
+                throw new UserException(sprintf(
+                    'Replication group "%s" refresh failed (phase %s).',
+                    $groupName,
+                    $failedPhase,
+                ));
+            }
+
+            if (self::isRefreshComplete($rows)) {
+                $logger->info(sprintf('Replication group "%s" refresh completed.', $groupName));
+                return;
+            }
+
+            $elapsed = $clock() - $startedAt;
+            if ($elapsed >= $timeoutSeconds) {
+                throw new UserException(sprintf(
+                    'Replication group "%s" refresh did not complete within %d seconds.',
+                    $groupName,
+                    $timeoutSeconds,
+                ));
+            }
+        }
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $rows
+     */
+    public static function isRefreshComplete(array $rows): bool
+    {
+        foreach ($rows as $row) {
+            if (self::phaseName($row) === 'COMPLETED') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if any row reports a terminal failure phase (FAILED|CANCELED).
+     *
+     * @param array<int,array<string,mixed>> $rows
+     */
+    public static function isRefreshFailed(array $rows): bool
+    {
+        return self::failedPhase($rows) !== null;
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $rows
+     */
+    private static function failedPhase(array $rows): ?string
+    {
+        foreach ($rows as $row) {
+            $phase = self::phaseName($row);
+            if (in_array($phase, self::TERMINAL_FAILURE_PHASES, true)) {
+                return $phase;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Case-insensitive read of the PHASE_NAME column (Snowflake returns upper-cased keys).
+     *
+     * @param array<string,mixed> $row
+     */
+    private static function phaseName(array $row): string
+    {
+        $value = $row['PHASE_NAME'] ?? $row['phase_name'] ?? '';
+        return strtoupper(is_scalar($value) ? (string) $value : '');
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $rows
+     */
+    private function logProgress(string $groupName, array $rows, LoggerInterface $logger): void
+    {
+        foreach ($rows as $row) {
+            $progressValue = $row['PROGRESS'] ?? $row['progress'] ?? '?';
+            $progress = is_scalar($progressValue) ? (string) $progressValue : '?';
+            $logger->info(sprintf(
+                'Replication group "%s" refresh phase "%s": %s%%',
+                $groupName,
+                self::phaseName($row) !== '' ? self::phaseName($row) : 'UNKNOWN',
+                $progress,
+            ));
+        }
+    }
+
+    /**
+     * @param string[] $databases
+     */
+    private static function quoteDatabaseList(array $databases): string
+    {
+        return implode(', ', array_map(
+            fn(string $db): string => Helper::quoteIdentifier($db),
+            $databases,
+        ));
+    }
+}

--- a/src/Snowflake/ReplicationGroup.php
+++ b/src/Snowflake/ReplicationGroup.php
@@ -48,7 +48,7 @@ class ReplicationGroup
         return sprintf(
             'CREATE REPLICATION GROUP IF NOT EXISTS %s '
             . 'OBJECT_TYPES = DATABASES '
-            . 'ALLOWED_DATABASES %s '
+            . 'ALLOWED_DATABASES = %s '
             . 'ALLOWED_ACCOUNTS = %s.%s;',
             Helper::quoteIdentifier($groupName),
             self::quoteDatabaseList($databases),
@@ -63,7 +63,7 @@ class ReplicationGroup
     public static function setAllowedDatabasesSql(string $groupName, array $databases): string
     {
         return sprintf(
-            'ALTER REPLICATION GROUP %s SET ALLOWED_DATABASES %s;',
+            'ALTER REPLICATION GROUP %s SET ALLOWED_DATABASES = %s;',
             Helper::quoteIdentifier($groupName),
             self::quoteDatabaseList($databases),
         );
@@ -91,7 +91,7 @@ class ReplicationGroup
     public static function refreshProgressSql(string $groupName): string
     {
         return sprintf(
-            'SELECT * FROM TABLE(INFORMATION_SCHEMA.REPLICATION_GROUP_REFRESH_PROGRESS(%s));',
+            'SELECT * FROM TABLE(SNOWFLAKE.INFORMATION_SCHEMA.REPLICATION_GROUP_REFRESH_PROGRESS(%s));',
             QueryBuilder::quote($groupName),
         );
     }

--- a/tests/phpunit/Configuration/ConfigTest.php
+++ b/tests/phpunit/Configuration/ConfigTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProjectMigrationTool\Tests\Configuration;
+
+use PHPUnit\Framework\TestCase;
+use ProjectMigrationTool\Configuration\Config;
+use ProjectMigrationTool\Configuration\ConfigDefinition;
+
+class ConfigTest extends TestCase
+{
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    private function makeConfig(array $parameters): Config
+    {
+        return new Config(['parameters' => $parameters], new ConfigDefinition());
+    }
+
+    public function testRefreshDefaults(): void
+    {
+        $config = $this->makeConfig([
+            'action' => Config::ACTION_MIGRATE_STRUCTURE,
+            'migrateDatabases' => ['DB1'],
+        ]);
+
+        self::assertSame(3600, $config->getReplicationRefreshTimeout());
+        self::assertSame(30, $config->getReplicationRefreshPollInterval());
+    }
+
+    public function testRefreshOverrides(): void
+    {
+        $config = $this->makeConfig([
+            'action' => Config::ACTION_MIGRATE_STRUCTURE,
+            'migrateDatabases' => ['DB1'],
+            'replicationRefreshTimeout' => 120,
+            'replicationRefreshPollInterval' => 5,
+        ]);
+
+        self::assertSame(120, $config->getReplicationRefreshTimeout());
+        self::assertSame(5, $config->getReplicationRefreshPollInterval());
+    }
+}

--- a/tests/phpunit/Snowflake/ReplicationGroupTest.php
+++ b/tests/phpunit/Snowflake/ReplicationGroupTest.php
@@ -28,20 +28,6 @@ class ReplicationGroupTest extends TestCase
         );
     }
 
-    public function testSetAllowedDatabasesSql(): void
-    {
-        $sql = ReplicationGroup::setAllowedDatabasesSql(
-            'MIGRATION_REPLICATION_GROUP',
-            ['DB1', 'DB2'],
-        );
-
-        self::assertSame(
-            'ALTER REPLICATION GROUP "MIGRATION_REPLICATION_GROUP" '
-            . 'SET ALLOWED_DATABASES = "DB1", "DB2";',
-            $sql,
-        );
-    }
-
     public function testCreateReplicaSql(): void
     {
         $sql = ReplicationGroup::createReplicaSql(

--- a/tests/phpunit/Snowflake/ReplicationGroupTest.php
+++ b/tests/phpunit/Snowflake/ReplicationGroupTest.php
@@ -89,6 +89,9 @@ class ReplicationGroupTest extends TestCase
 
         self::assertSame($name1, $name2);
         self::assertStringStartsWith('MIGRATION_RG_', $name1);
+        // Must be upper-cased so REPLICATION_GROUP_REFRESH_PROGRESS (which folds its string
+        // argument to upper case) can match the created group.
+        self::assertSame(strtoupper($name1), $name1);
     }
 
     public function testBuildNameIsCaseInsensitive(): void

--- a/tests/phpunit/Snowflake/ReplicationGroupTest.php
+++ b/tests/phpunit/Snowflake/ReplicationGroupTest.php
@@ -15,15 +15,15 @@ class ReplicationGroupTest extends TestCase
         $sql = ReplicationGroup::createOnSourceSql(
             'MIGRATION_REPLICATION_GROUP',
             ['DB1', 'DB2'],
-            'AWS_US_WEST_2',
-            'XY12345',
+            'MY_ORG',
+            'MIGRATE_ACCOUNT',
         );
 
         self::assertSame(
             'CREATE REPLICATION GROUP IF NOT EXISTS "MIGRATION_REPLICATION_GROUP" '
             . 'OBJECT_TYPES = DATABASES '
             . 'ALLOWED_DATABASES = "DB1", "DB2" '
-            . 'ALLOWED_ACCOUNTS = AWS_US_WEST_2.XY12345;',
+            . 'ALLOWED_ACCOUNTS = MY_ORG.MIGRATE_ACCOUNT;',
             $sql,
         );
     }
@@ -46,13 +46,13 @@ class ReplicationGroupTest extends TestCase
     {
         $sql = ReplicationGroup::createReplicaSql(
             'MIGRATION_REPLICATION_GROUP',
-            'AWS_US_EAST_1',
-            'SRCACCT',
+            'MY_ORG',
+            'SOURCE_ACCOUNT',
         );
 
         self::assertSame(
             'CREATE REPLICATION GROUP IF NOT EXISTS "MIGRATION_REPLICATION_GROUP" '
-            . 'AS REPLICA OF AWS_US_EAST_1.SRCACCT."MIGRATION_REPLICATION_GROUP";',
+            . 'AS REPLICA OF MY_ORG.SOURCE_ACCOUNT."MIGRATION_REPLICATION_GROUP";',
             $sql,
         );
     }

--- a/tests/phpunit/Snowflake/ReplicationGroupTest.php
+++ b/tests/phpunit/Snowflake/ReplicationGroupTest.php
@@ -22,7 +22,7 @@ class ReplicationGroupTest extends TestCase
         self::assertSame(
             'CREATE REPLICATION GROUP IF NOT EXISTS "MIGRATION_REPLICATION_GROUP" '
             . 'OBJECT_TYPES = DATABASES '
-            . 'ALLOWED_DATABASES "DB1", "DB2" '
+            . 'ALLOWED_DATABASES = "DB1", "DB2" '
             . 'ALLOWED_ACCOUNTS = AWS_US_WEST_2.XY12345;',
             $sql,
         );
@@ -37,7 +37,7 @@ class ReplicationGroupTest extends TestCase
 
         self::assertSame(
             'ALTER REPLICATION GROUP "MIGRATION_REPLICATION_GROUP" '
-            . 'SET ALLOWED_DATABASES "DB1", "DB2";',
+            . 'SET ALLOWED_DATABASES = "DB1", "DB2";',
             $sql,
         );
     }
@@ -68,7 +68,7 @@ class ReplicationGroupTest extends TestCase
     public function testRefreshProgressSql(): void
     {
         self::assertSame(
-            'SELECT * FROM TABLE(INFORMATION_SCHEMA.REPLICATION_GROUP_REFRESH_PROGRESS('
+            'SELECT * FROM TABLE(SNOWFLAKE.INFORMATION_SCHEMA.REPLICATION_GROUP_REFRESH_PROGRESS('
             . '\'MIGRATION_REPLICATION_GROUP\'));',
             ReplicationGroup::refreshProgressSql('MIGRATION_REPLICATION_GROUP'),
         );

--- a/tests/phpunit/Snowflake/ReplicationGroupTest.php
+++ b/tests/phpunit/Snowflake/ReplicationGroupTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProjectMigrationTool\Tests\Snowflake;
+
+use Keboola\Component\UserException;
+use PHPUnit\Framework\TestCase;
+use ProjectMigrationTool\Snowflake\ReplicationGroup;
+
+class ReplicationGroupTest extends TestCase
+{
+    public function testCreateSqlOnSource(): void
+    {
+        $sql = ReplicationGroup::createOnSourceSql(
+            'MIGRATION_REPLICATION_GROUP',
+            ['DB1', 'DB2'],
+            'AWS_US_WEST_2',
+            'XY12345',
+        );
+
+        self::assertSame(
+            'CREATE REPLICATION GROUP IF NOT EXISTS "MIGRATION_REPLICATION_GROUP" '
+            . 'OBJECT_TYPES = DATABASES '
+            . 'ALLOWED_DATABASES "DB1", "DB2" '
+            . 'ALLOWED_ACCOUNTS = AWS_US_WEST_2.XY12345;',
+            $sql,
+        );
+    }
+
+    public function testSetAllowedDatabasesSql(): void
+    {
+        $sql = ReplicationGroup::setAllowedDatabasesSql(
+            'MIGRATION_REPLICATION_GROUP',
+            ['DB1', 'DB2'],
+        );
+
+        self::assertSame(
+            'ALTER REPLICATION GROUP "MIGRATION_REPLICATION_GROUP" '
+            . 'SET ALLOWED_DATABASES "DB1", "DB2";',
+            $sql,
+        );
+    }
+
+    public function testCreateReplicaSql(): void
+    {
+        $sql = ReplicationGroup::createReplicaSql(
+            'MIGRATION_REPLICATION_GROUP',
+            'AWS_US_EAST_1',
+            'SRCACCT',
+        );
+
+        self::assertSame(
+            'CREATE REPLICATION GROUP IF NOT EXISTS "MIGRATION_REPLICATION_GROUP" '
+            . 'AS REPLICA OF AWS_US_EAST_1.SRCACCT."MIGRATION_REPLICATION_GROUP";',
+            $sql,
+        );
+    }
+
+    public function testRefreshSql(): void
+    {
+        self::assertSame(
+            'ALTER REPLICATION GROUP "MIGRATION_REPLICATION_GROUP" REFRESH;',
+            ReplicationGroup::refreshSql('MIGRATION_REPLICATION_GROUP'),
+        );
+    }
+
+    public function testRefreshProgressSql(): void
+    {
+        self::assertSame(
+            'SELECT * FROM TABLE(INFORMATION_SCHEMA.REPLICATION_GROUP_REFRESH_PROGRESS('
+            . '\'MIGRATION_REPLICATION_GROUP\'));',
+            ReplicationGroup::refreshProgressSql('MIGRATION_REPLICATION_GROUP'),
+        );
+    }
+
+    public function testDropSql(): void
+    {
+        self::assertSame(
+            'DROP REPLICATION GROUP IF EXISTS "MIGRATION_REPLICATION_GROUP";',
+            ReplicationGroup::dropSql('MIGRATION_REPLICATION_GROUP'),
+        );
+    }
+
+    public function testBuildNameIsDeterministicAndOrderIndependent(): void
+    {
+        $name1 = ReplicationGroup::buildName(['DB2', 'DB1']);
+        $name2 = ReplicationGroup::buildName(['DB1', 'DB2']);
+
+        self::assertSame($name1, $name2);
+        self::assertStringStartsWith('MIGRATION_RG_', $name1);
+    }
+
+    public function testBuildNameIsCaseInsensitive(): void
+    {
+        self::assertSame(
+            ReplicationGroup::buildName(['db1', 'DB2']),
+            ReplicationGroup::buildName(['DB1', 'db2']),
+        );
+    }
+
+    public function testBuildNameDiffersForDifferentDatabaseSets(): void
+    {
+        self::assertNotSame(
+            ReplicationGroup::buildName(['DB1', 'DB2']),
+            ReplicationGroup::buildName(['DB1', 'DB3']),
+        );
+    }
+
+    public function testWaitForRefreshCompletesAfterInProgressTransition(): void
+    {
+        // In-progress phases first, then COMPLETED — verifies the in-progress→completed transition.
+        $progressResponses = [
+            [['PHASE_NAME' => 'PRIMARY_UPLOADING', 'PROGRESS' => '40']],
+            [['PHASE_NAME' => 'SECONDARY_DOWNLOADING', 'PROGRESS' => '80']],
+            [['PHASE_NAME' => 'COMPLETED', 'PROGRESS' => '100']],
+        ];
+        $logger = new TestLogger();
+        $sleptTimes = 0;
+
+        $group = new ReplicationGroup();
+        $group->waitForRefresh(
+            'MIGRATION_REPLICATION_GROUP',
+            fetchProgress: function () use (&$progressResponses) {
+                return array_shift($progressResponses);
+            },
+            sleeper: function (int $seconds) use (&$sleptTimes): void {
+                $sleptTimes++;
+            },
+            clock: fn(): int => 1000,
+            logger: $logger,
+            timeoutSeconds: 3600,
+            pollIntervalSeconds: 30,
+        );
+
+        // polled 3 times, slept twice (between polls)
+        self::assertSame(2, $sleptTimes);
+        self::assertTrue($logger->hasInfoThatContains('PRIMARY_UPLOADING'));
+        self::assertTrue($logger->hasInfoThatContains('COMPLETED'));
+    }
+
+    public function testWaitForRefreshCompletesImmediatelyOnCompletedPhase(): void
+    {
+        $logger = new TestLogger();
+        $sleptTimes = 0;
+
+        $group = new ReplicationGroup();
+        $group->waitForRefresh(
+            'MIGRATION_REPLICATION_GROUP',
+            fetchProgress: fn(): array => [['PHASE_NAME' => 'COMPLETED', 'PROGRESS' => '100']],
+            sleeper: function (int $seconds) use (&$sleptTimes): void {
+                $sleptTimes++;
+            },
+            clock: fn(): int => 1000,
+            logger: $logger,
+            timeoutSeconds: 3600,
+            pollIntervalSeconds: 30,
+        );
+
+        // First poll already COMPLETED — no sleeping.
+        self::assertSame(0, $sleptTimes);
+        self::assertTrue($logger->hasInfoThatContains('COMPLETED'));
+    }
+
+    public function testWaitForRefreshThrowsOnFailedPhase(): void
+    {
+        $logger = new TestLogger();
+        $group = new ReplicationGroup();
+
+        $this->expectException(UserException::class);
+        $this->expectExceptionMessage('Replication group "MIGRATION_REPLICATION_GROUP" refresh failed (phase FAILED)');
+
+        $group->waitForRefresh(
+            'MIGRATION_REPLICATION_GROUP',
+            fetchProgress: fn(): array => [['PHASE_NAME' => 'FAILED', 'PROGRESS' => '0']],
+            sleeper: fn(int $seconds): null => null,
+            clock: fn(): int => 1000,
+            logger: $logger,
+            timeoutSeconds: 3600,
+            pollIntervalSeconds: 30,
+        );
+    }
+
+    public function testWaitForRefreshThrowsOnCanceledPhase(): void
+    {
+        $logger = new TestLogger();
+        $group = new ReplicationGroup();
+
+        $this->expectException(UserException::class);
+        $this->expectExceptionMessage(
+            'Replication group "MIGRATION_REPLICATION_GROUP" refresh failed (phase CANCELED)',
+        );
+
+        $group->waitForRefresh(
+            'MIGRATION_REPLICATION_GROUP',
+            fetchProgress: fn(): array => [['PHASE_NAME' => 'CANCELED', 'PROGRESS' => '0']],
+            sleeper: fn(int $seconds): null => null,
+            clock: fn(): int => 1000,
+            logger: $logger,
+            timeoutSeconds: 3600,
+            pollIntervalSeconds: 30,
+        );
+    }
+
+    public function testWaitForRefreshThrowsOnTimeout(): void
+    {
+        $logger = new TestLogger();
+        $now = 1000;
+
+        $group = new ReplicationGroup();
+
+        $this->expectException(UserException::class);
+        $this->expectExceptionMessage(
+            'Replication group "MIGRATION_REPLICATION_GROUP" refresh did not complete within 60 seconds',
+        );
+
+        $group->waitForRefresh(
+            'MIGRATION_REPLICATION_GROUP',
+            fetchProgress: fn(): array => [['PHASE_NAME' => 'PRIMARY_UPLOADING', 'PROGRESS' => '40']],
+            sleeper: function (int $seconds) use (&$now): void {
+                $now += $seconds;
+            },
+            clock: function () use (&$now): int {
+                return $now;
+            },
+            logger: $logger,
+            timeoutSeconds: 60,
+            pollIntervalSeconds: 30,
+        );
+    }
+}

--- a/tests/phpunit/Snowflake/TestLogger.php
+++ b/tests/phpunit/Snowflake/TestLogger.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProjectMigrationTool\Tests\Snowflake;
+
+use Psr\Log\AbstractLogger;
+use Stringable;
+
+/**
+ * Minimal in-test logger replacing the unavailable \Psr\Log\Test\TestLogger.
+ * Records all log messages and exposes a substring helper for assertions.
+ */
+class TestLogger extends AbstractLogger
+{
+    /** @var array<int, array{level: mixed, message: string}> */
+    public array $records = [];
+
+    /**
+     * @param array<mixed> $context
+     */
+    public function log(mixed $level, string|Stringable $message, array $context = []): void
+    {
+        $this->records[] = [
+            'level' => $level,
+            'message' => (string) $message,
+        ];
+    }
+
+    public function hasInfoThatContains(string $needle): bool
+    {
+        foreach ($this->records as $record) {
+            if ($record['level'] === 'info' && str_contains($record['message'], $needle)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the fragile per-database Snowflake replication (`ALTER DATABASE ... ENABLE REPLICATION` + blind `sleep(5)` + per-database `REFRESH`) with a single, re-runnable Snowflake **replication group**. As recommended by Snowflake, replicating related databases together in one group preserves cross-database zero-copy clone relationships and avoids physically materializing shared micro-partitions, which inflated storage usage during migrations.

## Changes

- **Replication group instead of per-database replication.** `PrepareMigration::createReplication()` now creates one replication group on the source account, replicates it to the migrate account, and refreshes it once. Membership is reconciled idempotently via `CREATE REPLICATION GROUP IF NOT EXISTS` + `ALTER REPLICATION GROUP ... SET ALLOWED_DATABASES`, so re-runs reuse the same group and pull deltas.
- **Deterministic group name.** The group name is derived from the migrated database set (`MIGRATION_RG_<hash>`, from the upper-cased + sorted database list). The same migration reuses the same group across runs (idempotent), while migrations with different database sets get distinct names so parallel migrations never collide.
- **Refresh polling instead of blind sleep.** New `Snowflake\ReplicationGroup` polls `REPLICATION_GROUP_REFRESH_PROGRESS` until completion. Terminal phases are handled explicitly: `COMPLETED` → success, `FAILED`/`CANCELED` → `UserException`, timeout → `UserException`. Progress is logged on each poll. The blind `sleep(5)` is removed.
- **Configurable timeout/poll interval.** New optional parameters `replicationRefreshTimeout` (default `3600`s) and `replicationRefreshPollInterval` (default `30`s).
- **Teardown in cleanup phase.** `Cleanup::teardownReplication()` (invoked from `runCleanup` after `postMigration`) drops the replication group on both accounts. Because dropping a secondary replication group leaves its member databases behind as writable standalone databases, it also drops those replica databases on the migrate account to free their names and reclaim storage. Same-region migrations are a no-op.

## Behavior preserved

- Same-region migrations still use sharing only — replication group creation/teardown are no-ops.
- Sharing and the target-side clone/grant flow are unchanged; roles/users/grants are still applied to the final writable database on the target account.

## Tests

Unit tests added for the SQL builders, deterministic name derivation, and the refresh polling loop (success, in-progress transition, failed/canceled, timeout) using injected sleeper/clock so no real sleeping or live DB is required. `phpcs`, `phpstan` (level max), and `phpunit` all pass.

Linear: AJDA-2604